### PR TITLE
fix: let listRepo queries also include base data

### DIFF
--- a/src/features/discussions/index.ts
+++ b/src/features/discussions/index.ts
@@ -61,13 +61,16 @@ export async function fetchDiscussionsData({
   const defaultQuery = await graphqlParser('discussions', 'default.gql')
   const listRepoQuery = await graphqlParser('discussions', 'list-repo.gql')
 
-  if (listRepo) {
-    return await fetchDiscussionsRepoList(listRepoQuery, variables)
-  }
-
   const {
-    data: { user: discussionsData },
+    data: { user },
   } = await fetcher(defaultQuery, variables)
+
+  let discussionsData = { ...user }
+
+  if (listRepo) {
+    const repoList = await fetchDiscussionsRepoList(listRepoQuery, variables)
+    discussionsData = { ...discussionsData, repoList }
+  }
 
   return discussionsData
 }

--- a/test/discussions.test.ts
+++ b/test/discussions.test.ts
@@ -26,9 +26,11 @@ describe('Discussions', () => {
     expect(response.type).toEqual('application/json')
     expect(response.body).toHaveProperty('discussions')
 
-    const { discussions } = response.body
+    const {
+      discussions: { repoList },
+    } = response.body
 
-    discussions.forEach((repo: any) => {
+    repoList.forEach((repo: any) => {
       expect(repo).toHaveProperty('repo')
       expect(repo).toHaveProperty('avatarUrl')
     })
@@ -43,9 +45,11 @@ describe('Discussions', () => {
     expect(response.type).toEqual('application/json')
     expect(response.body).toHaveProperty('discussions')
 
-    const { discussions } = response.body
+    const {
+      discussions: { repoList },
+    } = response.body
 
-    discussions.forEach((repo: any) => {
+    repoList.forEach((repo: any) => {
       expect(repo).toHaveProperty('repo')
       expect(repo).toHaveProperty('avatarUrl')
     })


### PR DESCRIPTION
This PR ensures that the base data (started, comments, answers) to be returned when querying via listRepo